### PR TITLE
TRUS-4141 [CS] upgrade bootstrap to v5.3 & sbt-auto-build plugin to 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 lazy val appName: String = "register-trust-other-individual-frontend"
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin, SbtArtifactory, SbtSassify)
+  .enablePlugins(PlayScala, SbtDistributablesPlugin, SbtSassify)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     DefaultBuildSettings.scalaSettings,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,7 +11,7 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "play-conditional-form-mapping"  % "1.6.0-play-27",
     "uk.gov.hmrc"       %% "domain"                         % "5.10.0-play-27",
     "com.typesafe.play" %% "play-json-joda"                 % "2.7.4",
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-27"     % "4.1.0",
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-27"     % "5.3.0",
     "uk.gov.hmrc"       %% "play-language"                  % "4.10.0-play-27"
   )
 
@@ -24,7 +24,7 @@ object AppDependencies {
     "org.mockito"              %  "mockito-all"           % "1.10.19",
     "org.scalacheck"           %% "scalacheck"            % "1.14.0",
     "wolfendale"               %% "scalacheck-gen-regexp" % "0.1.2",
-    "com.github.tomakehurst"   % "wiremock-standalone"    % "2.25.1"
+    "com.github.tomakehurst"   % "wiremock-standalone"    % "2.27.2"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,13 +2,9 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.14.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.13.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
 


### PR DESCRIPTION
Upgrading `sbt-auto-build` to 3.0 means we can remove some plugins
